### PR TITLE
Toggle "[?]" display when meta.description

### DIFF
--- a/jqPropertyGrid.js
+++ b/jqPropertyGrid.js
@@ -154,7 +154,7 @@
 
 		// If label (for read-only)
         	} else if (type === 'label') {
-			if (meta.description !== undefined) {
+			if (typeof meta.description === 'string' && meta.description) {
 	                	valueHTML = '<label for="' + elemId + '" title="' + meta.description + '">' + value + '</label>';
 	            	} else {
 		                valueHTML = '<label for="' + elemId + '">' + value + '</label>';
@@ -167,7 +167,7 @@
 		}
 
 		if (typeof meta.description === 'string' && meta.description) {
-			if (meta.showhelp !== false) {
+			if (meta.showHelp !== false) {
         			displayName += '<span class="pgTooltip" title="' + meta.description + '">[?]</span>';
             		}
 		}

--- a/jqPropertyGrid.js
+++ b/jqPropertyGrid.js
@@ -167,7 +167,9 @@
 		}
 
 		if (typeof meta.description === 'string' && meta.description) {
-			displayName += '<span class="pgTooltip" title="' + meta.description + '">[?]</span>';
+			if (meta.showhelp !== false) {
+        			displayName += '<span class="pgTooltip" title="' + meta.description + '">[?]</span>';
+            		}
 		}
 
 		return '<tr class="pgRow"><td class="pgCell">' + displayName + '</td><td class="pgCell">' + valueHTML + '</td></tr>';


### PR DESCRIPTION
With the addition of the label type, and update to label having a title, I don't want to show the [?] span. meta.showhelp flag allows disabling this span.